### PR TITLE
Superwhisper Skill 

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -30,7 +30,6 @@
             "command": "${CLAUDE_HOOK:-/Applications/superwhisper.app/Contents/Resources/claude-hook}"
           }
         ]
-      }
     ],
     "PermissionRequest": [
       {

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -30,6 +30,7 @@
             "command": "${CLAUDE_HOOK:-/Applications/superwhisper.app/Contents/Resources/claude-hook}"
           }
         ]
+      }
     ],
     "PermissionRequest": [
       {

--- a/skills/superwhisper/SKILL.md
+++ b/skills/superwhisper/SKILL.md
@@ -4,17 +4,10 @@ description: Toggle Superwhisper agent integration (on/off/toggle)
 args: on|off or empty to toggle
 ---
 
-Run this bash command exactly. The argument is: $ARGUMENTS
+Run this bash command exactly:
 
 ```bash
-h=$(echo -n "$PWD" | md5 -q 2>/dev/null || echo -n "$PWD" | md5sum | cut -d' ' -f1)
-f="/tmp/superwhisper-agent/disabled-$h"
-mkdir -p /tmp/superwhisper-agent
-case "$1" in
-  on)  rm -f "$f"; echo "Superwhisper: ON" ;;
-  off) touch "$f"; echo "Superwhisper: OFF" ;;
-  *)   [ -f "$f" ] && { rm -f "$f"; echo "Superwhisper: ON"; } || { touch "$f"; echo "Superwhisper: OFF"; } ;;
-esac
+echo "__superwhisper_toggle__ $ARGUMENTS"
 ```
 
-Report the single-line output to the user. Nothing else.
+Report the result to the user. Nothing else.

--- a/skills/superwhisper/SKILL.md
+++ b/skills/superwhisper/SKILL.md
@@ -7,7 +7,7 @@ args: on|off or empty to toggle
 Run this bash command exactly:
 
 ```bash
-echo "__superwhisper_toggle__ $ARGUMENTS"
+h=$(echo -n "$PWD" | md5 -q 2>/dev/null || echo -n "$PWD" | md5sum | cut -d' ' -f1); f="/tmp/superwhisper-agent/disabled-$h"; mkdir -p /tmp/superwhisper-agent; case "$ARGUMENTS" in on) rm -f "$f"; echo "Superwhisper: ON" ;; off) touch "$f"; echo "Superwhisper: OFF" ;; *) [ -f "$f" ] && { rm -f "$f"; echo "Superwhisper: ON"; } || { touch "$f"; echo "Superwhisper: OFF"; } ;; esac
 ```
 
-Report the result to the user. Nothing else.
+Report the single-line output to the user. Nothing else.


### PR DESCRIPTION
### Summary
Previous skill didnt seem to actually do anything when I was testing it, claudes explination 


> The bash used case "$1" in to read the argument (on/off), but $1 is a shell positional argument — it's only set when a script is called with arguments like ./script.sh off. When Claude runs bash via the Bash tool, it executes the code
  directly (not as a called script), so $1 is always empty. This meant on and off never matched, and it always fell through to the * toggle case — so you could never explicitly set a state, only toggle.
